### PR TITLE
vampirc-uci-19 - Fix 'go' parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ The full API documentation is available at [docs.rs](https://docs.rs/vampirc-uci
 To support negative durations, the representation of millisecond-based time quantities has been switched
 from Rust standard library's `std::time::Duration` to the [chrono crate's](https://crates.io/crates/chrono)
 `chrono::Duration` ([doc](https://docs.rs/chrono/0.4.15/chrono/struct.Duration.html)). This is an API-breaking change, hence the version increase.
+* Fix for [vampric-uci-19](https://github.com/vampirc/vampirc-uci/issues/19), a sometimes incorrect parsing of the `go` message.
 
 ### New in 0.10.1
 * Republish as 0.10.1 due to improper publish. 

--- a/res/uci.pest
+++ b/res/uci.pest
@@ -70,12 +70,14 @@ ply_clock = { counter }
 move_num = { counter }
 
 // GO
-go = ${ ^"go" ~ (WHITESPACE+ | go_time | go_search)* }
+go = {go_full | go_empty}
+go_empty = ${ ^"go" ~ WHITESPACE* ~  (EOI | NEWLINE) }
+go_full = ${ ^"go" ~ (WHITESPACE+  ~ (go_time | go_search | EOI | NEWLINE))+ }
 go_time = { go_ponder | go_infinite | go_movetime | go_timeleft }
 go_ponder = ${ ^"ponder" ~ (!non_ws | EOI) }
 go_infinite = ${ ^"infinite" ~ (!non_ws | EOI) }
 go_movetime = ${ ^"movetime" ~ WHITESPACE+ ~ milliseconds }
-go_timeleft = { (wtime | btime | winc | binc | movestogo)+ }
+go_timeleft = ${ (wtime | btime | winc | binc | movestogo)+ }
 wtime = ${ ^"wtime" ~ WHITESPACE+ ~ milliseconds}
 btime = ${ ^"btime" ~ WHITESPACE+ ~ milliseconds}
 winc = ${ ^"winc" ~ WHITESPACE+ ~ milliseconds}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -255,74 +255,82 @@ fn do_parse_uci(s: &str, top_rule: Rule, mut ml: Option<&mut MessageList>) -> Re
 
                     for sp in pair.into_inner() {
                         match sp.as_rule() {
-                            Rule::go_time => {
-                                for spi in sp.into_inner() {
-                                    match spi.as_rule() {
-                                        Rule::go_ponder => {
-                                            time_control = Some(UciTimeControl::Ponder);
-                                        }
-                                        Rule::go_infinite => {
-                                            time_control = Some(UciTimeControl::Infinite);
-                                        }
-                                        Rule::go_movetime => {
-                                            time_control = Some(UciTimeControl::MoveTime(
-                                                Duration::milliseconds(parse_milliseconds(spi)),
-                                            ));
-                                        }
-                                        Rule::go_timeleft => {
-                                            if !tl {
-                                                tl = true;
-                                            }
+                            Rule::go_empty => {}
+                            Rule::go_full => {
+                                for sp_full in sp.into_inner() {
+                                    match sp_full.as_rule() {
+                                        Rule::go_time => {
+                                            for spi in sp_full.into_inner() {
+                                                match spi.as_rule() {
+                                                    Rule::go_ponder => {
+                                                        time_control = Some(UciTimeControl::Ponder);
+                                                    }
+                                                    Rule::go_infinite => {
+                                                        time_control = Some(UciTimeControl::Infinite);
+                                                    }
+                                                    Rule::go_movetime => {
+                                                        time_control = Some(UciTimeControl::MoveTime(
+                                                            Duration::milliseconds(parse_milliseconds(spi)),
+                                                        ));
+                                                    }
+                                                    Rule::go_timeleft => {
+                                                        if !tl {
+                                                            tl = true;
+                                                        }
 
-                                            for sspi in spi.into_inner() {
-                                                match sspi.as_rule() {
-                                                    Rule::wtime => {
-                                                        wtime = Some(parse_milliseconds(sspi));
+                                                        for sspi in spi.into_inner() {
+                                                            match sspi.as_rule() {
+                                                                Rule::wtime => {
+                                                                    wtime = Some(parse_milliseconds(sspi));
+                                                                }
+                                                                Rule::btime => {
+                                                                    btime = Some(parse_milliseconds(sspi));
+                                                                }
+                                                                Rule::winc => {
+                                                                    winc = Some(parse_milliseconds(sspi));
+                                                                }
+                                                                Rule::binc => {
+                                                                    binc = Some(parse_milliseconds(sspi));
+                                                                }
+                                                                Rule::movestogo => {
+                                                                    moves_to_go =
+                                                                        Some(parse_u8(sspi, Rule::digits3));
+                                                                }
+                                                                _ => {}
+                                                            };
+                                                        }
                                                     }
-                                                    Rule::btime => {
-                                                        btime = Some(parse_milliseconds(sspi));
+
+                                                    _ => {}
+                                                }
+                                            }
+                                        }
+                                        Rule::go_search => {
+                                            for spi in sp_full.into_inner() {
+                                                match spi.as_rule() {
+                                                    Rule::depth => {
+                                                        search.depth = Some(parse_u8(spi, Rule::digits3));
                                                     }
-                                                    Rule::winc => {
-                                                        winc = Some(parse_milliseconds(sspi));
+                                                    Rule::mate => {
+                                                        search.mate = Some(parse_u8(spi, Rule::digits3))
                                                     }
-                                                    Rule::binc => {
-                                                        binc = Some(parse_milliseconds(sspi));
+                                                    Rule::nodes => {
+                                                        search.nodes = Some(parse_u64(spi, Rule::digits12))
                                                     }
-                                                    Rule::movestogo => {
-                                                        moves_to_go =
-                                                            Some(parse_u8(sspi, Rule::digits3));
+                                                    Rule::searchmoves => {
+                                                        for mt in spi.into_inner() {
+                                                            search.search_moves.push(parse_a_move(mt));
+                                                        }
                                                     }
                                                     _ => {}
-                                                };
+                                                }
                                             }
                                         }
-
-                                        _ => {}
+                                        _ => unreachable!()
                                     }
                                 }
                             }
-                            Rule::go_search => {
-                                for spi in sp.into_inner() {
-                                    match spi.as_rule() {
-                                        Rule::depth => {
-                                            search.depth = Some(parse_u8(spi, Rule::digits3));
-                                        }
-                                        Rule::mate => {
-                                            search.mate = Some(parse_u8(spi, Rule::digits3))
-                                        }
-                                        Rule::nodes => {
-                                            search.nodes = Some(parse_u64(spi, Rule::digits12))
-                                        }
-                                        Rule::searchmoves => {
-                                            for mt in spi.into_inner() {
-                                                search.search_moves.push(parse_a_move(mt));
-                                            }
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                            }
-                            _ => {}
+                            _ => unreachable!(),
                         }
                     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2455,8 +2455,7 @@ mod tests {
         assert_eq!(test_msg, parsed_msg);
     }
 
-    // TODO this fails for the wrong reason, parsing DOES not fail, it returns an essential empty GO message
-    #[ignore]
+    // TODO this fails for the wrong reason, parsing DOES not fail, it returns an essentially empty GO message
     #[test]
     fn test_parse_signed_improperly_duration_wtime() {
         let parsed_msg = parse_one("go wtime !15030 btime +56826 movestogo 90\n");


### PR DESCRIPTION
A weird case where an erroneous 'go' message is parsed as an empty message instead of producing an error.