### PR TITLE
Fix serialization of btime parameter

### DIFF
--- a/src/uci.rs
+++ b/src/uci.rs
@@ -412,7 +412,7 @@ impl Serializable for UciMessage {
                             }
 
                             if let Some(bt) = black_time {
-                                s += format!("bt {} ", bt.num_milliseconds()).as_str();
+                                s += format!("btime {} ", bt.num_milliseconds()).as_str();
                             }
 
                             if let Some(wi) = white_increment {


### PR DESCRIPTION
"`bt`" here seems to be a copy-paste issue - It should be "`btime`".